### PR TITLE
[ssu-ks] allow to override default ssu parameters.

### DIFF
--- a/macros.ssuks
+++ b/macros.ssuks
@@ -11,7 +11,7 @@
     sleep 1 \
     for M in %{?*}; do \
         for B in true false; do  \
-            ssuks model="$M" sandbox=/tmp/sandbox outputdir=%{buildroot}/%{_datadir}/kickstarts/ rnd=$B version=%{version} \
+            ssuks %{?ssu_override} model="$M" sandbox=/tmp/sandbox outputdir=%{buildroot}/%{_datadir}/kickstarts/ rnd=$B version=%{version} \
         done \
     done \
 %{nil}


### PR DESCRIPTION
When making kickstarts, defining values in spec with ssu_override will overwrite parameters coming e.g. from repos.ini.
