### PR TITLE
Forward declare QDomDocument

### DIFF
--- a/libssu/ssu.h
+++ b/libssu/ssu.h
@@ -12,10 +12,9 @@
 #include <QObject>
 #include <QDebug>
 
-#include <QtXml/QDomDocument>
-
 class QNetworkAccessManager;
 class QNetworkReply;
+class QDomDocument;
 
 class Ssu: public QObject {
     Q_OBJECT

--- a/tests/ut_urlresolver/urlresolvertest.cpp
+++ b/tests/ut_urlresolver/urlresolvertest.cpp
@@ -6,6 +6,9 @@
  */
 
 #include "urlresolvertest.h"
+
+#include <QtXml/QDomDocument>
+
 #include "constants.h"
 #include "testutils/process.h"
 


### PR DESCRIPTION
Saves other packages from including QT+=xml in their project file until
actually needed.
