### PR TITLE
[ssu] separate connman dependency to a plugin library

### DIFF
--- a/libssunetworkproxy/libssunetworkproxy.pri
+++ b/libssunetworkproxy/libssunetworkproxy.pri
@@ -1,0 +1,2 @@
+include(libssunetworkproxy_dependencies.pri)
+LIBS *= -ldl

--- a/libssunetworkproxy/libssunetworkproxy.pro
+++ b/libssunetworkproxy/libssunetworkproxy.pro
@@ -1,0 +1,12 @@
+TARGET = ssunetworkproxy
+include(../ssulibrary.pri)
+
+HEADERS = ssunetworkproxy.h
+
+SOURCES = ssunetworkproxy.cpp
+
+CONFIG += link_pkgconfig plugin
+
+QT += network
+
+PKGCONFIG += connman-qt5

--- a/libssunetworkproxy/libssunetworkproxy_dependencies.pri
+++ b/libssunetworkproxy/libssunetworkproxy_dependencies.pri
@@ -1,0 +1,1 @@
+# none yet

--- a/libssunetworkproxy/ssunetworkproxy.cpp
+++ b/libssunetworkproxy/ssunetworkproxy.cpp
@@ -1,0 +1,13 @@
+/**
+ * @file ssunetworkproxy.cpp
+ * @copyright 2014 Jolla Ltd.
+ * @author Juha Kallioinen <juha.kallioinen@jolla.com>
+ * @date 2014
+ */
+
+#include <connman-qt5/connmannetworkproxyfactory.h>
+
+extern "C" void initialize()
+{
+    QNetworkProxyFactory::setApplicationProxyFactory(new ConnmanNetworkProxyFactory);
+}

--- a/libssunetworkproxy/ssunetworkproxy.h
+++ b/libssunetworkproxy/ssunetworkproxy.h
@@ -1,0 +1,31 @@
+/**
+ * @file ssunetworkproxy.h
+ * @copyright 2014 Jolla Ltd.
+ * @author Juha Kallioinen <juha.kallioinen@jolla.com>
+ * @date 2014
+ */
+
+#ifndef _LibSsuNetworkProxy_H
+#define _LibSsuNetworkProxy_H
+#include <dlfcn.h>
+
+/**
+ * Set application proxy if the required library is found, otherwise
+ * do nothing.
+ */
+inline void set_application_proxy_factory()
+{
+    void *proxylib = dlopen("libssunetworkproxy.so", RTLD_LAZY);
+    if (proxylib) {
+        typedef void (*ssuproxyinit_t)();
+        dlerror();
+        ssuproxyinit_t proxy_init = (ssuproxyinit_t) dlsym(proxylib, "initialize");
+        const char *dlsym_err = dlerror();
+        if (!dlsym_err) {
+            proxy_init();
+        }
+        dlclose(proxylib);
+    }
+}
+
+#endif

--- a/rndssucli/main.cpp
+++ b/rndssucli/main.cpp
@@ -10,7 +10,7 @@
 #include <QLocale>
 #include <QLibraryInfo>
 #include <QTimer>
-#include <connman-qt5/connmannetworkproxyfactory.h>
+#include "libssunetworkproxy/ssunetworkproxy.h"
 #include "rndssucli.h"
 
 int main(int argc, char** argv){
@@ -24,7 +24,7 @@ int main(int argc, char** argv){
                     QLibraryInfo::location(QLibraryInfo::TranslationsPath));
   app.installTranslator(&qtTranslator);
 
-  QNetworkProxyFactory::setApplicationProxyFactory(new ConnmanNetworkProxyFactory);
+  set_application_proxy_factory();
 
   RndSsuCli mw;
   QTimer::singleShot(0, &mw, SLOT(run()));

--- a/rndssucli/rndssucli.pro
+++ b/rndssucli/rndssucli.pro
@@ -4,7 +4,6 @@ include(rndssucli_dependencies.pri)
 
 QT += network dbus
 CONFIG += link_pkgconfig
-PKGCONFIG += connman-qt5
 
 HEADERS = rndssucli.h \
         ssuproxy.h

--- a/rndssucli/rndssucli_dependencies.pri
+++ b/rndssucli/rndssucli_dependencies.pri
@@ -1,1 +1,2 @@
 include(../libssu/libssu.pri)
+include(../libssunetworkproxy/libssunetworkproxy.pri)

--- a/rpm/ssu.spec
+++ b/rpm/ssu.spec
@@ -23,6 +23,7 @@ Requires(pre): shadow-utils
 Requires(pre): /usr/bin/groupadd-user
 Requires(postun): shadow-utils
 Requires: ssu-vendor-data
+Requires: ssu-network-proxy
 
 %description
 %{summary}.
@@ -32,7 +33,7 @@ Requires: ssu-vendor-data
 %{_libdir}/zypp/plugins/urlresolver/*
 %{_bindir}/rndssu
 %{_bindir}/ssu
-%{_libdir}/*.so.*
+%{_libdir}/libssu.so.*
 %dir %{_sysconfdir}/zypp/credentials.d
 # ssu itself does not use the package-update triggers, but provides
 # them for the vendor data packages to use
@@ -40,6 +41,18 @@ Requires: ssu-vendor-data
 %{_bindir}/ssud
 %{_datadir}/dbus-1/system-services/*.service
 %{_sysconfdir}/dbus-1/system.d/*.conf
+
+%package network-proxy-plugin
+Summary: Network Proxy support for ssu
+Group: System/Base
+Provides: ssu-network-proxy
+
+%description network-proxy-plugin
+%{summary}.
+
+%files network-proxy-plugin
+%defattr(-,root,root,-)
+%{_libdir}/libssunetworkproxy.so
 
 %package vendor-data-example
 Summary: Sample vendor configuration data

--- a/ssu.pro
+++ b/ssu.pro
@@ -3,7 +3,7 @@ contains(QT_VERSION, ^4\\.[0-7]\\..*) {
 }
 
 TEMPLATE = subdirs
-SUBDIRS = libssu ssud
+SUBDIRS = libssu libssunetworkproxy ssud
 SUBDIRS += rndssucli ssuurlresolver ssuks
 
 ssuconfhack {

--- a/ssud/main.cpp
+++ b/ssud/main.cpp
@@ -9,7 +9,7 @@
 #include <QTranslator>
 #include <QLocale>
 #include <QLibraryInfo>
-#include <connman-qt5/connmannetworkproxyfactory.h>
+#include "libssunetworkproxy/ssunetworkproxy.h"
 #include "ssud.h"
 
 int main(int argc, char** argv){
@@ -23,7 +23,7 @@ int main(int argc, char** argv){
                     QLibraryInfo::location(QLibraryInfo::TranslationsPath));
   app.installTranslator(&qtTranslator);
 
-  QNetworkProxyFactory::setApplicationProxyFactory(new ConnmanNetworkProxyFactory);
+  set_application_proxy_factory();
 
   Ssud ssud;
 

--- a/ssud/ssud.pro
+++ b/ssud/ssud.pro
@@ -4,7 +4,6 @@ include(ssud_dependencies.pri)
 
 QT += network dbus
 CONFIG += link_pkgconfig
-PKGCONFIG += connman-qt5
 
 HEADERS = ssuadaptor.h \
         ssud.h

--- a/ssud/ssud_dependencies.pri
+++ b/ssud/ssud_dependencies.pri
@@ -1,1 +1,2 @@
 include(../libssu/libssu.pri)
+include(../libssunetworkproxy/libssunetworkproxy.pri)

--- a/ssuurlresolver/main.cpp
+++ b/ssuurlresolver/main.cpp
@@ -10,7 +10,7 @@
 #include <QLocale>
 #include <QLibraryInfo>
 #include <QTimer>
-#include <connman-qt5/connmannetworkproxyfactory.h>
+#include "libssunetworkproxy/ssunetworkproxy.h"
 #include "ssuurlresolver.h"
 
 int main(int argc, char** argv){
@@ -24,7 +24,7 @@ int main(int argc, char** argv){
                     QLibraryInfo::location(QLibraryInfo::TranslationsPath));
   app.installTranslator(&qtTranslator);
 
-  QNetworkProxyFactory::setApplicationProxyFactory(new ConnmanNetworkProxyFactory);
+  set_application_proxy_factory();
 
   SsuUrlResolver mw;
   QTimer::singleShot(0, &mw, SLOT(run()));

--- a/ssuurlresolver/ssuurlresolver.pro
+++ b/ssuurlresolver/ssuurlresolver.pro
@@ -8,7 +8,6 @@ target.path = /usr/lib/zypp/plugins/urlresolver
 
 QT += network
 CONFIG += link_pkgconfig
-PKGCONFIG += connman-qt5
 
 HEADERS = ssuurlresolver.h
 SOURCES = main.cpp \

--- a/ssuurlresolver/ssuurlresolver_dependencies.pri
+++ b/ssuurlresolver/ssuurlresolver_dependencies.pri
@@ -1,1 +1,2 @@
 include(../libssu/libssu.pri)
+include(../libssunetworkproxy/libssunetworkproxy.pri)


### PR DESCRIPTION
New package ssu-network-proxy-plugin provides ssu-network-proxy,
which is required by ssu.

Signed-off-by: Juha Kallioinen juha.kallioinen@jolla.com
