### PR TITLE
Prevent ssu startup when system is shutting down.

### DIFF
--- a/dbus/org.nemo.ssu.service
+++ b/dbus/org.nemo.ssu.service
@@ -1,5 +1,7 @@
 [D-BUS Service]
 Interface=org.nemo.ssu
 Name=org.nemo.ssu
-Exec=/usr/bin/ssud
+Exec=/bin/false
 User=root
+SystemdService=dbus-org.nemo.ssu.service
+

--- a/rpm/ssu.spec
+++ b/rpm/ssu.spec
@@ -36,6 +36,7 @@ Requires: ssu-network-proxy
 # them for the vendor data packages to use
 %attr(0755, -, -) %{_oneshotdir}/*
 %{_bindir}/ssud
+/lib/systemd/system/*.service
 %{_datadir}/dbus-1/system-services/*.service
 %{_sysconfdir}/dbus-1/system.d/*.conf
 

--- a/ssud/ssud.pro
+++ b/ssud/ssud.pro
@@ -13,10 +13,13 @@ SOURCES = ssuadaptor.cpp \
 
 DBUS_SERVICE_NAME=org.nemo.ssu
 
+systemd.files = ../systemd/dbus-$${DBUS_SERVICE_NAME}.service
+systemd.path = /lib/systemd/system/
+
 service.files = ../dbus/$${DBUS_SERVICE_NAME}.service
 service.path = /usr/share/dbus-1/system-services/
 
 conf.files = ../dbus/$${DBUS_SERVICE_NAME}.conf
 conf.path = /etc/dbus-1/system.d/
 
-INSTALLS += service conf
+INSTALLS += systemd service conf

--- a/systemd/dbus-org.nemo.ssu.service
+++ b/systemd/dbus-org.nemo.ssu.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=SSU service
+
+[Service]
+Type=dbus
+BusName=org.nemo.ssu
+ExecStart=/usr/bin/ssud
+


### PR DESCRIPTION
[systemd] Prevent ssu startup when system is shutting down. Contributes to JB#24120

We need to map the dbus service file to systemd service file in order to
be able to prevent dbus activation of the service when system is for
example shutting down.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>