### PR TITLE
[toolchain] Revert C++11 changes for GCC 4.6 compatibility

### DIFF
--- a/ssuurlresolver/ssuurlresolver.pro
+++ b/ssuurlresolver/ssuurlresolver.pro
@@ -9,9 +9,6 @@ target.path = /usr/lib/zypp/plugins/urlresolver
 QT += network
 CONFIG += link_pkgconfig
 
-# Needed for recent versions of libzypp
-QMAKE_CXXFLAGS += -std=c++11
-
 HEADERS = ssuurlresolver.h
 SOURCES = main.cpp \
         ssuurlresolver.cpp

--- a/tests/ut_ssucli/ut_ssucli.pro
+++ b/tests/ut_ssucli/ut_ssucli.pro
@@ -18,6 +18,3 @@ test_data_usr_share.files = \
 
 test_data_boardmappings_d.files = \
         testdata/board-mappings.ini \
-
-# Needed for recent versions of libzypp
-QMAKE_CXXFLAGS += -std=c++11

--- a/tests/ut_ssuurlresolver/ut_ssuurlresolver.pro
+++ b/tests/ut_ssuurlresolver/ut_ssuurlresolver.pro
@@ -21,6 +21,3 @@ test_data_usr_share.files = \
 
 test_data_boardmappings_d.files = \
         testdata/board-mappings.ini \
-
-# Needed for recent versions of libzypp
-QMAKE_CXXFLAGS += -std=c++11


### PR DESCRIPTION
This reverts commit 62a2de4444965c3d4071a6ff35c836a0da0ce6aa.