### PR TITLE
[ssuurlresolver] Compile with C++11 (Contributes to JB#25649)

### DIFF
--- a/ssuurlresolver/ssuurlresolver.pro
+++ b/ssuurlresolver/ssuurlresolver.pro
@@ -9,6 +9,9 @@ target.path = /usr/lib/zypp/plugins/urlresolver
 QT += network
 CONFIG += link_pkgconfig
 
+# Needed for recent versions of libzypp
+QMAKE_CXXFLAGS += -std=c++11
+
 HEADERS = ssuurlresolver.h
 SOURCES = main.cpp \
         ssuurlresolver.cpp

--- a/tests/ut_ssucli/ut_ssucli.pro
+++ b/tests/ut_ssucli/ut_ssucli.pro
@@ -18,3 +18,6 @@ test_data_usr_share.files = \
 
 test_data_boardmappings_d.files = \
         testdata/board-mappings.ini \
+
+# Needed for recent versions of libzypp
+QMAKE_CXXFLAGS += -std=c++11

--- a/tests/ut_ssuurlresolver/ut_ssuurlresolver.pro
+++ b/tests/ut_ssuurlresolver/ut_ssuurlresolver.pro
@@ -21,3 +21,6 @@ test_data_usr_share.files = \
 
 test_data_boardmappings_d.files = \
         testdata/board-mappings.ini \
+
+# Needed for recent versions of libzypp
+QMAKE_CXXFLAGS += -std=c++11


### PR DESCRIPTION
Now that GCC 4.6 is finally out the window, and GCC 4.8 is out the door, re-merge the previously-merged-then-reverted patch for libzypp support.